### PR TITLE
Send ACK messages

### DIFF
--- a/src/net/CUDPComm.cpp
+++ b/src/net/CUDPComm.cpp
@@ -700,7 +700,7 @@ Boolean CUDPComm::AsyncWrite() {
         outData.c = theConnection->WriteAcks(outData.c);
 
         if (thePacket == kPleaseSendAcknowledge) {
-            thePacket = theConnection->GetOutPacket(curTime, (cramCount-- > 0) ? CRAMTIME : 0, CRAMTIME);
+            packetList = theConnection->GetOutPacket(curTime, (cramCount-- > 0) ? CRAMTIME : 0, CRAMTIME);
         }
 
         while (thePacket && thePacket != kPleaseSendAcknowledge) {
@@ -785,7 +785,7 @@ Boolean CUDPComm::AsyncWrite() {
         theConnection->quota -= udp->len;
 
         curTime = GetClock();
-        while (packetList) {
+        while (packetList && packetList != kPleaseSendAcknowledge) {
             thePacket = (UDPPacketInfo *)packetList->packet.qLink;
 
             if (packetList->birthDate ==


### PR DESCRIPTION
I'm not sure how/if this ever worked because after checking if (thePacket == kPleaseSendAcknowledge) it would immediately call GetOutPacket and change thePacket.  Subsequent checks to see if it was an ACK would not have succeeded.

In my testing of the "server-as-router" feature/experiemnt, I witnessed some problems with the fact that ACKs weren't being sent.  For instance, some clients would continually resend some messages until they got an ACK back.  This fix would satisfy those requests.

It's possible that this fix might solve some one-off issues we have seen but I can't guarantee it.  But that's why I pulled it into it's own commit so that we can pull it into master and do further testing on the master branch.